### PR TITLE
Refactor logging setup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import datetime
 import threading
 import os
 import logging
+from utils.logging_utils import setup_logging
 import asyncio
 
 import yt_dlp
@@ -16,15 +17,8 @@ from ytdlp_config import FETCH_OPTS, DOWNLOAD_OPTS, DEFAULT_OUTPUT_TEMPLATE
 from twitch_chat import TwitchChatRetriever, extract_video_id
 from twitch_chat_ui import TwitchChatUI
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler("twitch_archiver.log"),
-        logging.StreamHandler()
-    ]
-)
+# Configure logging using shared utility
+setup_logging(log_level=logging.INFO, log_file="twitch_archiver.log")
 logger = logging.getLogger("TwitchVODArchiver")
 chat_logger = logging.getLogger("TwitchChatRetriever")
 chat_logger.setLevel(logging.DEBUG)  # Set chat logger to DEBUG level

--- a/src/test_twitch_chat.py
+++ b/src/test_twitch_chat.py
@@ -7,19 +7,13 @@ import sys
 import time
 import json
 import logging
+from utils.logging_utils import setup_logging
 import argparse
 import asyncio
 from twitch_chat import TwitchChatRetriever
 
 # Set up logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(),
-        logging.FileHandler("chat_download_test.log")
-    ]
-)
+setup_logging(log_level=logging.DEBUG, log_file="chat_download_test.log")
 logger = logging.getLogger("ChatTest")
 
 def load_credentials():


### PR DESCRIPTION
## Summary
- centralize log configuration with `setup_logging`
- use the shared logging utility in `main.py`
- apply same setup to `test_twitch_chat.py`

## Testing
- `python -m py_compile src/main.py src/test_twitch_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858dfc1ec3c8321b98d3154ee931aee